### PR TITLE
Removing run_once to fix issue #2

### DIFF
--- a/tasks/swarm_cluster.yml
+++ b/tasks/swarm_cluster.yml
@@ -29,9 +29,15 @@
   when: "'docker_swarm_manager' in group_names
     and inventory_hostname != groups['docker_swarm_manager'][0]"
 
-- name: Export the address of the first Swarm manager as a fact.
+- name: Declare the address of the first Swarm manager as a fact.
   set_fact:
-    docker_manager_address: "{{ hostvars[groups['docker_swarm_manager'][0]]['docker_swarm_addr'] }}:{{ docker_swarm_port }}"
+    docker_manager_address: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
+  when: "inventory_hostname == groups['docker_swarm_manager'][0]"
+
+- name: Distribute the address of the first Swarm manager fact.
+  set_fact:
+    docker_manager_address: "{{hostvars[groups['docker_swarm_manager'][0]]['docker_manager_address'] }}"
+  when: "inventory_hostname != groups['docker_swarm_manager'][0]"
 
 - name: Join the pending Swarm worker nodes.
   shell: docker swarm join

--- a/tasks/swarm_cluster.yml
+++ b/tasks/swarm_cluster.yml
@@ -15,22 +15,23 @@
 - name: Get the worker join-token.
   shell: docker swarm join-token -q worker
   changed_when: False
-  run_once: true
   register: docker_worker_token
-  when: inventory_hostname == groups['docker_swarm_manager'][0]
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  delegate_facts: True
+  when: "'docker_swarm_worker' in group_names"
 
 - name: Get the manager join-token.
   shell: docker swarm join-token -q manager
   changed_when: False
-  run_once: true
   register: docker_manager_token
-  when: inventory_hostname == groups['docker_swarm_manager'][0]
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  delegate_facts: True
+  when: "'docker_swarm_manager' in group_names
+    and inventory_hostname != groups['docker_swarm_manager'][0]"
 
 - name: Export the address of the first Swarm manager as a fact.
   set_fact:
-    docker_manager_address: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
-  run_once: true
-  when: inventory_hostname == groups['docker_swarm_manager'][0]
+    docker_manager_address: "{{ hostvars[groups['docker_swarm_manager'][0]]['docker_swarm_addr'] }}:{{ docker_swarm_port }}"
 
 - name: Join the pending Swarm worker nodes.
   shell: docker swarm join

--- a/tasks/swarm_cluster.yml
+++ b/tasks/swarm_cluster.yml
@@ -34,7 +34,7 @@
     docker_manager_address: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
   when: "inventory_hostname == groups['docker_swarm_manager'][0]"
 
-- name: Distribute the address of the first Swarm manager fact.
+- name: Distribute the fact containing address of the first Swarm manager.
   set_fact:
     docker_manager_address: "{{hostvars[groups['docker_swarm_manager'][0]]['docker_manager_address'] }}"
   when: "inventory_hostname != groups['docker_swarm_manager'][0]"


### PR DESCRIPTION
This PR aims to fix issue #2 reported by @riemers replacing `run_one` with action and facts delegation (see http://docs.ansible.com/ansible/playbooks_delegation.html#delegation for more informations): `run_once`, in fact, strictly relies on the declaration order of the hosts into the Ansible inventory.
