### PR TITLE
Ability to set interface name listened by docker swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,17 @@ The value of `default_docker_dependencies` depends on the target OS family.
 Setting `skip_engine: True` will make the role skip the installation of `docker-engine`.
 If you want to use this role to just install `docker-engine` without enabling `swarm-mode` set `skip_swarm: True`.
 
+    docker_swarm_interface: "{{ ansible_default_ipv4['alias'] }}"
+
+Setting `docker_swarm_interface` allows you to define which network interface will be used for cluster inter-communication.
+
+    docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_interface]['ipv4']['address'] }}"
+
+In this case ip address for raft API will be taken from desired interface:
+
     docker_swarm_addr: "{{ ansible_default_ipv4['address'] }}"
 
-Listening address where the raft APIs will be exposed.
+Or you can setup listening address where the raft APIs will be exposed, by your own.
 
     docker_swarm_port: 2377
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,10 @@ docker_dependencies: "{{ default_docker_dependencies }}"
 skip_engine: False
 skip_swarm: False
 
-docker_swarm_addr: "{{ ansible_default_ipv4['address'] }}"
+# Instead of {{ ansible_default_ipv4['alias'] }} you can set any interface, that is listened by docker engine.
+# E.g.
+# docker_swarm_interface: "eth1"
+docker_swarm_interface: "{{ ansible_default_ipv4['alias'] }}"
+docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_interface]['ipv4']['address'] }}"
 docker_swarm_port: 2377
 # docker_swarm_secret: "supersecret"


### PR DESCRIPTION
While I was testing role on vagrant machines, I've faced an issue:
Default interface was eth0, but I created additional private network, and I needed to connect swarm nodes via its interface, e.g. eth1.
So this PR adds ability to switch docker_swarm_addr to another interface address.
