### PR TITLE
Use keyserver option in apt_key

### DIFF
--- a/tasks/docker_engine.yml
+++ b/tasks/docker_engine.yml
@@ -2,7 +2,7 @@
 
 - name: Import Docker APT public key.
   apt_key:
-    url: "{{ docker_pubkey_url }}"
+    keyserver: "{{ docker_pubkey_server }}"
     id: "{{ docker_pubkey_id }}"
     state: present
   when: ansible_os_family == 'Debian'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
-docker_pubkey_id: "0x58118e89f3a912897c070adbf76221572c52609d"
-docker_pubkey_url: "https://sks-keyservers.net/pks/lookup?op=get&search={{ docker_pubkey_id }}"
+docker_pubkey_id: "58118E89F3A912897C070ADBF76221572C52609D"
+docker_pubkey_server: "hkp://p80.pool.sks-keyservers.net:80"
 
 docker_apt_repo: "deb https://apt.dockerproject.org/repo {{ ansible_distribution | lower }}-{{ ansible_distribution_release }} {{ docker_repo }}"
 


### PR DESCRIPTION
While running a playbook, I got the following error:

```
Failed to validate the SSL certificate for sks-keyservers.net:443. Make sure your
managed systems have a valid CA certificate installed. You can use validate_certs=False
if you do not need to confirm the servers identity but this is unsafe and not recommended.
Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem,
/etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible
```

This patch uses `keyserver` option instead of `url` in `apt_key` to avoid it.