### PR TITLE
Allow to run docker swarm on customized network

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ docker_repo: main
 # Extra packages that have to be installed together with Docker
 docker_dependencies: "{{ default_docker_dependencies }}"
 
+# Docker swarm network can be define in order to be sure that
+# swarm cluster doesn't overlap with you infrastructure
+# docker_swarm_network: 10.10.8.0/24
+
 # You can set any interface, that is listened by docker engine.
 # e.g. docker_swarm_interface: "eth1"
 docker_swarm_interface: "{{ ansible_default_ipv4['interface'] }}"

--- a/tasks/swarm_cluster.yml
+++ b/tasks/swarm_cluster.yml
@@ -1,5 +1,19 @@
 ---
 
+- name: Create a custom swarm network
+  docker_network:
+    name: docker_gwbridge
+    driver_options:
+      com.docker.network.bridge.enable_icc: "false"
+      com.docker.network.bridge.enable_ip_masquerade: "true"
+      com.docker.network.bridge.name: docker_gwbridge
+    ipam_options:
+      subnet: "{{ docker_swarm_network }}"
+      gateway: "{{ docker_swarm_network | ipaddr('net') | ipaddr('1') | ipaddr('ip') }}"
+  tags:
+    - skip_ansible_lint # Suppressing the linter
+  when: docker_swarm_network is defined and docker_swarm_network | ipaddr('net')
+
 - name: Check if "Swarm Mode" is enabled.
   shell: docker info
   changed_when: False


### PR DESCRIPTION
Default docker network, which is created during swarm cluster
init process, can potentially overlap with an existing one in
local network. This patch introduce change which allows to
redefine docker swarm network by defining:
  docker_swarm_network: 10.10.8.0/24

by default docker_swarm_network is not defined