### PR TITLE
Allow to define labels to docker swarm nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,38 @@ If you want to use this role to just install `docker-engine` without enabling `s
 To skip the tasks adding the `docker_admin_users` to the `docker_group` set `skip_group: True`.
 Finally, the `docker-py` installation task can be skipped setting `skip_docker_py` to `True`.
 
+Swarm node labels
+-----------------
+
+[Node labels](https://docs.docker.com/engine/swarm/manage-nodes/#add-or-remove-label-metadata) provide a
+flexible method of node organization. You can also use node labels in service constraints.
+Apply constraints when you create a service to limit the nodes where the scheduler assigns tasks for the service.
+You can define labels by `swarm_labels` variable, e.g:
+
+    $ cat inventory
+    ...
+    [docker_swarm_manager]
+    swarm-01 swarm_labels=deploy
+
+    [docker_swarm_worker]
+    swarm-02 swarm_labels='["libvirt", "docker", "foo", "bar"]'
+    swarm-03
+    ...
+
+In this case:
+
+    $ docker inspect --format '{{json .Spec.Labels}}'  swarm-02 | jq
+    {
+       "bar": "true",
+       "docker": "true",
+       "for": "true",
+       "libvirt": "true",
+    }
+
+You can assign labels to cluster running playbook with `--tags=swarm_labels`
+
+**NB**: Please note, all labels that are not defined in inventory will be removed
+
 Dependencies
 ------------
 
@@ -79,10 +111,10 @@ Example Playbook
     swarm-03
 
     [docker_swarm_manager]
-    swarm-01
+    swarm-01 swarm_labels=deploy
 
     [docker_swarm_worker]
-    swarm-02
+    swarm-02 swarm_labels='["libvirt", "docker", "foo", "bar"]'
     swarm-03
 
     $ cat playbook.yml

--- a/molecule.yml
+++ b/molecule.yml
@@ -7,9 +7,23 @@ ansible:
     vbox_hosts: # this group is needed to override the default ansible variables when running molecule with the virtualbox driver
       # While the names of the net ifaces changes, the internal subnet is consistent in each platform
       - docker_swarm_addr: "{{ ansible_all_ipv4_addresses | select('match', '172.28.128.*') | first }}"
+  host_vars:
+    ansible-dockerswarm-01:
+      - swarm_labels: foo
+    ansible-dockerswarm-02:
+      - swarm_labels:
+          - bar
+          - libvirt
   raw_env_vars:
     # Fix an issue with the docker driver
     ANSIBLE_REMOTE_TMP: "/tmp"
+  # Uncomment to verify swarm_labels
+  # tags:
+  #   swarm_labels
+
+# Uncomment if docker is going to be used for local development
+# driver:
+#   name: docker
 
 # configuration options for the internal docker driver (used in CI)
 docker:

--- a/tasks/swarm_cluster.yml
+++ b/tasks/swarm_cluster.yml
@@ -87,3 +87,39 @@
     and inventory_hostname != groups['docker_swarm_manager'][0]"
   tags:
     - skip_ansible_lint # Suppressing the linter
+
+- name: Get list of labels
+  command: >-
+         docker inspect
+         --format {% raw %}'{{range $key, $value := .Spec.Labels}}{{printf "%s\n" $key}}{{end}}'{% endraw %}
+         {{ ansible_hostname }}
+  register: docker_swarm_labels
+  changed_when: False
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  delegate_facts: True
+  tags:
+    - skip_ansible_lint
+    - swarm_labels
+
+- name: Remove labels from swarm node
+  command: docker node update --label-rm {{ item }} {{ ansible_hostname }}
+  with_items: "{{ docker_swarm_labels.stdout_lines }}"
+  when: "{{ docker_swarm_labels.stdout_lines | count > 0 }}"
+  changed_when: False
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  delegate_facts: True
+  tags:
+    - skip_ansible_lint
+    - swarm_labels
+
+- name: Asign labels to swarm nodes | if defined
+  command: docker node update --label-add {{ item }}=true {{ ansible_hostname }}
+  when: swarm_labels is defined
+  changed_when: False
+  with_items:
+    - "{{ swarm_labels }}"
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  delegate_facts: True
+  tags:
+    - skip_ansible_lint
+    - swarm_labels


### PR DESCRIPTION
This feature allows to define labels for swarm nodes [1]

[1]. https://docs.docker.com/engine/reference/commandline/node_update