### PR TITLE
Allow to re-define default docker daemon options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,15 @@ docker_repo: main
 # docker_repo: testing
 # docker_repo: experimental
 
+# Define docker daemon options
+docker_daemon_network: "172.18.0.1/16"
+docker_daemon_graph: "/var/lib/docker"
+docker_options: "--bip={{ docker_daemon_network }} --graph={{ docker_daemon_graph }}"
+# Define storage driver, which is aufs (by default), but can be overlay
+# Please check https://docs.docker.com/engine/userguide/storagedriver/selectadriver/
+# for details
+# docker_storage_options: -s overlay
+
 # Extra packages that have to be installed together with Docker
 docker_dependencies: "{{ default_docker_dependencies }}"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,28 @@
+---
+- name: restart docker
+  command: /bin/true
+  notify:
+    - reload systemd
+    - reload docker
+    - wait for docker
+    - docker is ready
+
+- name: reload systemd
+  command: systemctl daemon-reload
+
+- name: reload docker
+  service:
+    name: docker
+    state: restarted
+
+- name: wait for docker
+  pause:
+    seconds: 10
+    prompt: "Wait a little before docker start"
+
+- name: docker is ready
+  command: "/usr/bin/docker images"
+  register: docker_ready
+  retries: 10
+  delay: 5
+  until: docker_ready.rc == 0

--- a/tasks/docker_engine.yml
+++ b/tasks/docker_engine.yml
@@ -46,6 +46,10 @@
     name: docker-engine
     state: present
 
+- name: Configure systemd for docker
+  include: docker_systemd.yml
+  when: docker_options is defined
+
 - name: Enable the Docker daemon as a service and start it.
   service:
     name: docker

--- a/tasks/docker_systemd.yml
+++ b/tasks/docker_systemd.yml
@@ -1,0 +1,19 @@
+---
+- name: Write docker.service systemd file
+  template:
+    src: docker.service.j2
+    dest: /etc/systemd/system/docker.service
+
+- name: Ensure docker service systemd directory exists
+  file:
+    path: /etc/systemd/system/docker.service.d
+    state: directory
+
+- name: Write docker options systemd drop-in
+  template:
+    src: docker-options.conf.j2
+    dest: "/etc/systemd/system/docker.service.d/docker-options.conf"
+  notify: restart docker
+
+# restart docker just now and not at the end of play
+- meta: flush_handlers

--- a/templates/docker-options.conf.j2
+++ b/templates/docker-options.conf.j2
@@ -1,0 +1,5 @@
+[Service]
+Environment="DOCKER_OPTS={% if docker_options is defined %}{{ docker_options }}{% endif %}"
+{% if docker_storage_options is defined %}
+Environment="DOCKER_STORAGE_OPTIONS={{ docker_storage_options }}"
+{% endif %}

--- a/templates/docker.service.j2
+++ b/templates/docker.service.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=http://docs.docker.com
+{% if ansible_os_family == "RedHat" %}
+After=network.target docker-storage-setup.service
+Wants=docker-storage-setup.service
+{% elif ansible_os_family == "Debian" %}
+After=network.target docker.socket
+Wants=docker.socket
+{% endif %}
+
+[Service]
+Type=notify
+ExecReload=/bin/kill -s HUP $MAINPID
+Delegate=yes
+KillMode=process
+ExecStart=/usr/bin/docker daemon \
+          $DOCKER_OPTS \
+          $DOCKER_STORAGE_OPTIONS \
+          $DOCKER_NETWORK_OPTIONS \
+          $DOCKER_DNS_OPTIONS \
+          $INSECURE_REGISTRY
+TasksMax=infinity
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+TimeoutStartSec=1min
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* docker_options can be used to pass parameters to docker daemon:
   - docker_daemon_network
   - docker_daemon_graph
* docker_storage_options as well can be used to re-define default
  storage driver, e.g. overlay/overlay2