### PR TITLE
Fix swarm_labels

### DIFF
--- a/tasks/swarm_cluster.yml
+++ b/tasks/swarm_cluster.yml
@@ -112,12 +112,11 @@
     - skip_ansible_lint
     - swarm_labels
 
-- name: Asign labels to swarm nodes | if defined
+- name: Asign labels to swarm nodes | if any
   command: docker node update --label-add {{ item }}=true {{ ansible_hostname }}
-  when: swarm_labels is defined
   changed_when: False
   with_items:
-    - "{{ swarm_labels }}"
+    - "{{ swarm_labels  | default([]) }}"
   delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
   delegate_facts: True
   tags:


### PR DESCRIPTION
Problem: if swarm_labels not defined at all, it fails on the last step with:
```
fatal: [node2]: FAILED! => {"failed": true, "msg": "'swarm_labels' is undefined"}
```

Using `when swarm_labels is defined` [doesn't work with `with_items`](http://stackoverflow.com/questions/35470667/ansible-with-items-when-item-is-defined). Let's use defaults instead.
