### PR TITLE
Fixed custom interface

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ docker_dependencies: "{{ default_docker_dependencies }}"
 
 # You can set any interface, that is listened by docker engine.
 # e.g. docker_swarm_interface: "eth1"
-docker_swarm_interface: "{{ ansible_default_ipv4['interface'] }}"
+docker_swarm_interface: "{{ docker_swarm_interface | ansible_default_ipv4['interface'] }}"
 docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_interface]['ipv4']['address'] }}"
 docker_swarm_port: 2377
 


### PR DESCRIPTION
The custom `docker_swarm_interface` seems to be ignored.

The `docker_swarm_addr` variable is computed from from `docker_swarm_interface` variable.Since the actual variable necessary for the swarm tasks to be run is `docker_swarm_addr` and `docker_swarm_interface` value from external is overridden, any attempt to control the swarm interface has no effect.