### PR TITLE
added official handling of docker group adding

### DIFF
--- a/tasks/docker_group.yml
+++ b/tasks/docker_group.yml
@@ -19,3 +19,9 @@
   when: ansible_user is defined
     and ansible_user in docker_admin_users
     and ansible_user in "{{ addtogroup.results | selectattr('changed') | map(attribute='item') | list }}"
+
+# See https://stackoverflow.com/a/44753457
+- name: Reset ansible connection after group changes
+  meta: reset_connection
+  when: ansible_version.major = 2
+    and ansible_version.minor >= 3

--- a/tasks/docker_group.yml
+++ b/tasks/docker_group.yml
@@ -19,6 +19,7 @@
   when: ansible_user is defined
     and ansible_user in docker_admin_users
     and ansible_user in "{{ addtogroup.results | selectattr('changed') | map(attribute='item') | list }}"
+    and ansible_version.major <= 2 and ansible_version.minor <3
 
 # See https://stackoverflow.com/a/44753457
 - name: Reset ansible connection after group changes


### PR DESCRIPTION
#32 only for ansible 2.3 and newer! I'm not interested in older versions of ansible, If you care I can try fixing this. Let me know!

This use case is also used in the official role examples https://docs.ansible.com/ansible/2.4/meta_module.html#examples