### PR TITLE
If the host is also the swarm manager this should be skipped

### DIFF
--- a/tasks/swarm_cluster.yml
+++ b/tasks/swarm_cluster.yml
@@ -70,7 +70,8 @@
   changed_when: False
   when: "docker_info.stdout.find('Swarm: active') == -1
     and docker_info.stdout.find('Swarm: pending') == -1
-    and 'docker_swarm_worker' in group_names"
+    and 'docker_swarm_worker' in group_names
+    and 'docker_swarm_manager' not in group_names"
   tags:
     - skip_ansible_lint # Suppressing the linter
 


### PR DESCRIPTION
When using a single host for testing not having this check was causing this task to error, when it should just be skipped.