### PR TITLE
Fix version_compare deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - ANSIBLE=2.6
     - ANSIBLE=2.7
     - ANSIBLE=2.8
+    - ANSIBLE=2.9
 
 # Tests all the scenarios
 script:

--- a/tasks/setup-docker-group.yml
+++ b/tasks/setup-docker-group.yml
@@ -18,7 +18,7 @@
       poll: 2   # wait 2 seconds befor polling the task status
       failed_when: false  # suceed even if the command fails
       when: ansible_version is defined
-        and (ansible_version.full | version_compare('2.3.0.0', '<'))
+        and (ansible_version.full is version_compare('2.3.0.0', '<'))
 
     # See https://stackoverflow.com/a/44753457
     - name: Reset ansible connection after group changes (Ansible >= 2.3.0).

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27,36}-ansible{26,27,28}
+envlist = py{27,36}-ansible{26,27,28,29}
 skipsdist = true
 
 [travis:env]
@@ -8,13 +8,15 @@ ANSIBLE=
   2.6: ansible26
   2.7: ansible27
   2.8: ansible28
+  2.9: ansible29
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible28: ansible<2.9
-    ansible27: ansible<2.8
     ansible26: ansible<2.7
+    ansible27: ansible<2.8
+    ansible28: ansible<2.9
+    ansible29: ansible<2.10
 commands =
     {posargs:molecule test --all --destroy always}


### PR DESCRIPTION
This PR fixes the `version_compare` filter deprecation warnings reported in #55 and #48.

Closes #55 and #48.