### PR TITLE
Install gpg on Debian systems

### DIFF
--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -1,8 +1,10 @@
 ---
 
-- name: Install apt-transport-https if necessary.
+- name: Install apt-transport-https and gpg if necessary.
   apt:
-    name: apt-transport-https
+    name:
+      - apt-transport-https
+      - gpg
     state: present
 
 - name: Import Docker APT public key.


### PR DESCRIPTION
This PR makes sure that `gpg` is installed on Debian systems before executing the `apt_key` module.