### PR TITLE
Allow to override Docker and containerd systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Set it to `latest` to force the upgrade of the installed Docker packages.
 Additional support packages to be installed alongside Docker by the role.
 See `[vars/RedHat.yml](vars/RedHat.yml)` and `[vars/Debian.yml](vars/Debian.yml)` for the definition of the `default_docker_dependencies` variable.
 
+    docker_service_override: ""
+    # docker_service_override: |
+    # [Service]
+    # ExecStart=
+    # ExecStart=/usr/bin/dockerd
+
+Contect written to the systemd unit drop-in overriding
+the default Docker service definition.
+
     docker_service_state: "started"
     docker_service_enabled: "yes"
 
@@ -70,6 +79,13 @@ When set to `""` the latest available version will be installed.
    containerd_package_state: present
 
 Set it to `latest` to force the upgrade of the installed containerd package.
+
+    containerd_service_override: |
+      [Service]
+      ExecStartPre=
+
+Contect written to the systemd unit drop-in overriding
+the default containerd service definition.
 
     containerd_service_state: "started"
     containerd_service_enabled: "yes"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,14 @@ docker_package_state: present
 # e.g. linux-image-extra-virtual on some Debian systems
 docker_dependencies: "{{ default_docker_dependencies }}"
 
+# Contect written to the systemd unit drop-in overriding
+# the default Docker service definition.
+docker_service_override: ""
+# docker_service_override: |
+# [Service]
+# ExecStart=
+# ExecStart=/usr/bin/dockerd
+
 # State of the Docker deamon service
 docker_service_state: "started"
 
@@ -41,6 +49,12 @@ containerd_package_name: "containerd.io"
 # Version of the containerd package to be installed.
 # By default, the latest available version will be installed.
 containerd_package_version: ""
+
+# Contect written to the systemd unit drop-in overriding
+# the default containerd service definition.
+containerd_service_override: |
+  [Service]
+  ExecStartPre=
 
 # Installation state of the containerd package.
 # Set it to 'latest' to upgrade containerd.

--- a/tasks/setup-containerd.yml
+++ b/tasks/setup-containerd.yml
@@ -47,7 +47,7 @@
       daemon_reload: yes
     when: _containerd_systemd_override.changed
 
-  when: containerd_service_override != ""
+  when: containerd_service_override | length > 0
     and ansible_service_mgr == "systemd"
 
 - name: Enable the containerd daemon service and start it.

--- a/tasks/setup-containerd.yml
+++ b/tasks/setup-containerd.yml
@@ -48,7 +48,7 @@
     when: _containerd_systemd_override.changed
 
   when: containerd_service_override | length > 0
-    and ansible_service_mgr == "systemd"
+    and ansible_service_mgr == 'systemd'
 
 - name: Enable the containerd daemon service and start it.
   service:

--- a/tasks/setup-containerd.yml
+++ b/tasks/setup-containerd.yml
@@ -36,18 +36,19 @@
 
   - name: Override the systemd unit for containerd.
     template:
-      src: containerd.systemd.j2
-      dest: "/etc/systemd/system/containerd.service.d/settings.conf"
-    register: _containerd_systemd_unit
+      src: containerd-override.conf.j2
+      dest: "/etc/systemd/system/containerd.service.d/override.conf"
+    register: _containerd_systemd_override
 
   - name: Reload systemd and restart containerd.
     service:
       name: containerd
       state: "{% if containerd_service_state != 'stopped' %}restarted{% else %}stopped{% endif %}"
       daemon_reload: yes
-    when: _containerd_systemd_unit.changed
+    when: _containerd_systemd_override.changed
 
-  when: ansible_service_mgr == "systemd"
+  when: containerd_service_override != ""
+    and ansible_service_mgr == "systemd"
 
 - name: Enable the containerd daemon service and start it.
   service:

--- a/tasks/setup-docker-engine.yml
+++ b/tasks/setup-docker-engine.yml
@@ -39,7 +39,7 @@
       daemon_reload: yes
     when: _docker_systemd_override.changed
 
-  when: docker_service_override != ""
+  when: docker_service_override | length > 0
     ansible_service_mgr == "systemd"
 
 - name: Make sure the Docker daemon configuration directory exists

--- a/tasks/setup-docker-engine.yml
+++ b/tasks/setup-docker-engine.yml
@@ -19,6 +19,29 @@
     name: "{{ docker_package_name }}{{ _docker_package_version | default('') }}"
     state: "{{ docker_package_state }}"
 
+- block:
+
+  - name: Create the systemd overrides directory for Docker.
+    file:
+      name: "/etc/systemd/system/docker.service.d"
+      state: directory
+
+  - name: Override the systemd unit for Docker.
+    template:
+      src: docker-override.conf.j2
+      dest: "/etc/systemd/system/docker.service.d/override.conf"
+    register: _docker_systemd_override
+
+  - name: Reload systemd and restart Docker.
+    service:
+      name: docker
+      state: "{% if docker_service_state != 'stopped' %}restarted{% else %}stopped{% endif %}"
+      daemon_reload: yes
+    when: _docker_systemd_override.changed
+
+  when: docker_service_override != ""
+    ansible_service_mgr == "systemd"
+
 - name: Make sure the Docker daemon configuration directory exists
   file:
     path: /etc/docker

--- a/tasks/setup-docker-engine.yml
+++ b/tasks/setup-docker-engine.yml
@@ -40,7 +40,7 @@
     when: _docker_systemd_override.changed
 
   when: docker_service_override | length > 0
-    ansible_service_mgr == "systemd"
+    and ansible_service_mgr == 'systemd'
 
 - name: Make sure the Docker daemon configuration directory exists
   file:

--- a/templates/containerd-override.conf.j2
+++ b/templates/containerd-override.conf.j2
@@ -1,0 +1,1 @@
+{{ containerd_service_override }}

--- a/templates/containerd.systemd.j2
+++ b/templates/containerd.systemd.j2
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPre=

--- a/templates/docker-override.conf.j2
+++ b/templates/docker-override.conf.j2
@@ -1,0 +1,1 @@
+{{ docker_service_override }}


### PR DESCRIPTION
Alternative implementation to #54 to override the systemd units for the Docker and containerd service.