### PR TITLE
Do not install epel-release on Fedora

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,37 +11,8 @@
   when: ansible_os_family == 'Debian'
   changed_when: false
 
-# The with_items is required here to make
-# sure epel-release is configured on the host
-# before installing the python-pip package
-- name: Install python-pip.
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ python_pip_packages }}"
-  when: (not skip_docker_py) or (not skip_docker_compose)
-    or (ansible_os_family == 'Debian'
-    and ansible_python_version is version_compare('2.6.0', '>=')
-    and ansible_python_version is version_compare('2.7.9', '<'))
-
-- name: Install the Python SNI support packages.
-  package:
-    name: "{{ python_sni_support_packages }}"
-    state: present
-  when: ansible_os_family == 'Debian'
-    and ansible_python_version is version_compare('2.6.0', '>=')
-    and ansible_python_version is version_compare('2.7.9', '<')
-
-# There extra pip dependencies are needed to add SSL SNI support to
-# Python version prior to 2.7.9. SNI support is needed by the Ansible
-# apt_key module.
-- name: Install the Python SNI python-pip dependencies.
-  pip:
-    name: "{{ python_sni_pip_dependencies }}"
-    state: present
-  when: ansible_os_family == 'Debian'
-    and ansible_python_version is version_compare('2.6.0', '>=')
-    and ansible_python_version is version_compare('2.7.9', '<')
+# Install python-pip
+- include_tasks: setup-python-pip.yml
 
 # Install the Docker repository
 - include_tasks: "repo-{{ ansible_os_family }}.yml"

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -1,5 +1,24 @@
 ---
 
+- block:
+
+    - name: Install the Python SNI support packages.
+      package:
+        name: "{{ python_sni_support_packages }}"
+        state: present
+
+    # There extra pip dependencies are needed to add SSL SNI support to
+    # Python version prior to 2.7.9. SNI support is needed by the Ansible
+    # apt_key module.
+    - name: Install the Python SNI python-pip dependencies.
+      pip:
+        name: "{{ python_sni_pip_dependencies }}"
+        state: present
+
+  when: ansible_os_family == 'Debian'
+    and ansible_python_version is version_compare('2.6.0', '>=')
+    and ansible_python_version is version_compare('2.7.9', '<')
+
 - name: Install apt-transport-https and gpg if necessary.
   apt:
     name:

--- a/tasks/setup-python-pip.yml
+++ b/tasks/setup-python-pip.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Install epel-release
+  package:
+    name: "epel-release"
+    state: present
+  when: (not skip_docker_py) or (not skip_docker_compose)
+    and ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
+
+# The with_items is required here to make
+# sure epel-release is configured on the host
+# before installing the python-pip package
+- name: Install python-pip.
+  package:
+    name: "{{ python_pip_packages }}"
+    state: present
+  when: (not skip_docker_py) or (not skip_docker_compose)
+    or (ansible_os_family == 'Debian'
+    and ansible_python_version is version_compare('2.6.0', '>=')
+    and ansible_python_version is version_compare('2.7.9', '<'))

--- a/tasks/setup-python-pip.yml
+++ b/tasks/setup-python-pip.yml
@@ -4,8 +4,8 @@
   package:
     name: "epel-release"
     state: present
-  when: (not skip_docker_py) or (not skip_docker_compose)
-    and ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
+  when: ((not skip_docker_py) or (not skip_docker_compose))
+    and (ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora')
 
 # The with_items is required here to make
 # sure epel-release is configured on the host

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,7 +1,6 @@
 ---
 
 python_pip_packages:
-  - epel-release
   - "{% if ansible_python_version is version_compare('3.0.0', '<') %}python-pip{% else %}python3-pip{% endif %}"
 
 python_sni_support_packages: [ ]


### PR DESCRIPTION
This PR makes sure not to install `epel-release` on Fedora.