### PR TITLE
Install the docker cli independently from the docker-daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When set to `""` the latest available version will be installed.
 
     docker_package_state: present
 
-Set it to `latest` to force the upgrade of the installed Docker packages.
+Set it to `latest` to force the upgrade of the installed Docker package to the latest version.
 
     docker_dependencies: "{{ default_docker_dependencies }}"
 
@@ -69,6 +69,19 @@ State of the Docker service.
 Dictionary of Docker deamon configuration options to be written to `/etc/docker/daemon.json`.
 See [Daemon configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file) for the detailed documentation of the available options.
 
+    docker_cli_package_name: "docker-ce-cli"
+
+Name of the package providing the Docker CLI.
+
+    docker_cli_package_version: "{{ docker_package_version }}"
+
+Version of the Docker CLI package to be installed on the target hosts.
+When set to `""` the latest available version will be installed.
+
+    docker_cli_package_state: present
+
+Set it to `latest` to force the upgrade of the installed Docker CLI package to the latest version.
+
     containerd_package_name: "containerd.io"
 
 Name of the package providing containerd.
@@ -78,9 +91,9 @@ Name of the package providing containerd.
 Version of the containerd package to be installed.
 When set to `""` the latest available version will be installed.
 
-   containerd_package_state: present
+    containerd_package_state: present
 
-Set it to `latest` to force the upgrade of the installed containerd package.
+Set it to `latest` to force the upgrade of the installed containerd package to the latest version.
 
     containerd_service_override: |
       [Service]
@@ -122,8 +135,9 @@ Listen port for the Swarm raft API.
     skip_repo: false
     skip_containerd: false
     skip_engine: false
-    skip_group: false
+    skip_cli: false
     skip_swarm: false
+    skip_group: false
     skip_docker_py: false
     skip_docker_compose: false
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [Daemon configuration file](https://docs.docker.com/engine/reference/command
 
 Name of the package providing the Docker CLI.
 
-    docker_cli_package_version: "{{ docker_package_version }}"
+    docker_cli_package_version: ""
 
 Version of the Docker CLI package to be installed on the target hosts.
 When set to `""` the latest available version will be installed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@ docker_daemon_config: {}
 docker_cli_package_name: "docker-ce-cli"
 
 # Version of the Docker CLI package to be installed.
-docker_cli_package_version: "{{ docker_package_version }}"
+docker_cli_package_version: ""
 
 # Installation state of the Docker CLI package.
 # Set it to 'latest' to upgrade the Docker CLI to the latest version.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ docker_package_name: "docker-ce"
 docker_package_version: ""
 
 # Installation state of the Docker package.
-# Set it to 'latest' to upgrade Docker.
+# Set it to 'latest' to upgrade Docker to the latest version.
 docker_package_state: present
 
 # Extra packages that have to be installed together with Docker
@@ -40,6 +40,20 @@ docker_service_enabled: "yes"
 docker_daemon_config: {}
 
 ##
+# Docker CLI
+##
+
+# Name of the package providing the Docker CLI
+docker_cli_package_name: "docker-ce-cli"
+
+# Version of the Docker CLI package to be installed.
+docker_cli_package_version: "{{ docker_package_version }}"
+
+# Installation state of the Docker CLI package.
+# Set it to 'latest' to upgrade the Docker CLI to the latest version.
+docker_cli_package_state: present
+
+##
 # Containerd
 ##
 
@@ -50,15 +64,15 @@ containerd_package_name: "containerd.io"
 # By default, the latest available version will be installed.
 containerd_package_version: ""
 
+# Installation state of the containerd package.
+# Set it to 'latest' to upgrade containerd to the latest version.
+containerd_package_state: present
+
 # Contect written to the systemd unit drop-in overriding
 # the default containerd service definition.
 containerd_service_override: |
   [Service]
   ExecStartPre=
-
-# Installation state of the containerd package.
-# Set it to 'latest' to upgrade containerd.
-containerd_package_state: present
 
 # State of the containerd service
 containerd_service_state: "started"
@@ -107,7 +121,8 @@ docker_swarm_port: 2377
 skip_repo: false        # if true, skips the setup of the docker repository
 skip_containerd: false  # if true, skips the setup of containerd
 skip_engine: false      # if true, skips the docker engine installation
-skip_group: false       # if true, does not add the docker_admin_users to the docker_group_name
+skip_cli: false         # if true, skips the docker cli installation
 skip_swarm: false       # if true, skips the swarm setup
+skip_group: false       # if true, does not add the docker_admin_users to the docker_group_name
 skip_docker_py: false   # if true, skips the installation of docker-py
 skip_docker_compose: false  # if true, skips the installation of docker-compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,10 @@
 - include_tasks: setup-docker-engine.yml
   when: not skip_engine
 
+# Install the Docker CLI
+- include_tasks: setup-docker-cli.yml
+  when: not skip_cli
+
 # Setup the Docker Swarm Cluster
 - block:
     - include_tasks: setup-swarm-cluster.yml

--- a/tasks/setup-docker-cli.yml
+++ b/tasks/setup-docker-cli.yml
@@ -1,0 +1,20 @@
+---
+
+- block:
+
+    - name: Prefix the Docker CLI package version with the correct separator on RedHat.
+      set_fact:
+        _docker_cli_package_version: "-{{ docker_cli_package_version }}"
+      when: ansible_os_family == 'RedHat'
+
+    - name: Prefix the Docker CLI package version with the correct separator on Debian.
+      set_fact:
+        _docker_cli_package_version: "={{ docker_cli_package_version }}"
+      when: ansible_os_family == 'Debian'
+
+  when: docker_cli_package_version | length > 0
+
+- name: Install the Docker CLI.
+  package:
+    name: "{{ docker_cli_package_name }}{{ _docker_cli_package_version | default('') }}"
+    state: "{{ docker_cli_package_state }}"


### PR DESCRIPTION
Since docker `18.09.0` the `docker-ce-cli` is shipped standalone from the daemon.
This PR adds support to the installation of the CLI without installing the docker daemon.