### PR TITLE
Rename the gpg package to gnupg

### DIFF
--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -19,11 +19,11 @@
     and ansible_python_version is version_compare('2.6.0', '>=')
     and ansible_python_version is version_compare('2.7.9', '<')
 
-- name: Install apt-transport-https and gpg if necessary.
+- name: Install apt-transport-https and gnupg if necessary.
   apt:
     name:
       - apt-transport-https
-      - gpg
+      - gnupg
     state: present
 
 - name: Import Docker APT public key.


### PR DESCRIPTION
On recent Ubuntu versions, both the gnupg and gpg packages are available

```bash
# dpkg -l gnupg
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                                          Version                             Architecture                        Description
+++-=============================================================-===================================-===================================-================================================================================================================================
ii  gnupg                                                         2.2.4-1ubuntu1.2                    amd64                               GNU privacy guard - a free PGP replacement
root@k8s-cloud
```

```bash
# dpkg -l gpg
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                                          Version                             Architecture                        Description
+++-=============================================================-===================================-===================================-================================================================================================================================
ii  gpg                                                           2.2.4-1ubuntu1.2                    amd64                               GNU Privacy Guard -- minimalist public key operations
```

Let's use the `gnupg` package instead of `gpg` for compatibility with older Ubuntu releases.

Closes #71 