### PR TITLE
Pin the version of sh.py installed as Molecule dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,5 @@
 molecule==2.22.0
 docker==4.2.0
+
+# see https://github.com/ansible-community/molecule/pull/2682
+sh==1.12.14


### PR DESCRIPTION
This is fixing an issue preventing molecule to be executing correctly when Python 2.7 is used (see https://github.com/ansible-community/molecule/pull/2682)