### PR TITLE
Add variable which allows skipping labels task

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Listen port for the Swarm raft API.
     skip_engine: false
     skip_cli: false
     skip_swarm: false
+    skip_swarm_labels: false
     skip_group: false
     skip_docker_py: false
     skip_docker_compose: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,6 +137,7 @@ skip_containerd: false  # if true, skips the setup of containerd
 skip_engine: false      # if true, skips the docker engine installation
 skip_cli: false         # if true, skips the docker cli installation
 skip_swarm: false       # if true, skips the swarm setup
+skip_swarm_labels: false  # if true, skips the swarm labels assignment
 skip_group: false       # if true, does not add the docker_admin_users to the docker_group_name
 skip_docker_py: false   # if true, skips the installation of docker-py
 skip_docker_compose: false  # if true, skips the installation of docker-compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
 - block:
     - include_tasks: setup-swarm-cluster.yml
     - include_tasks: setup-swarm-labels.yml
+      when: not skip_swarm_labels
   when: not skip_swarm
 
 # Adds the Docker admin users to the Docker group


### PR DESCRIPTION
Bit of background: 

I'm using [docker-auto-labels](https://github.com/tiangolo/docker-auto-labels) which allows me to assign labels to random nodes. I don't use the labeling feature from this role and it seems the role deletes the label if it's not declared in the playbook.

So I added the `skip_swarm_labels` which allows skipping the `setup_swarm_labels` task altogether.