### PR TITLE
Feature : swarm client cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,17 @@ Listen port for the Swarm raft API.
     skip_engine: false
     skip_cli: false
     skip_swarm: false
+    skip_swarm_cert: false
     skip_group: false
     skip_docker_py: false
     skip_docker_compose: false
 
 Switches allowing to disable specific functionalities of the role.
 If you want to use this role to install `docker-engine` without enabling `swarm-mode` set `skip_swarm: true`.
+
+If you want to use this role to gen API certs, set `skip_swarm_cert: true`
+
+If you want to keep certs to local folder, set `docker_api_certs_docker_local_cert_path: /your/local/path`
 
 Swarm node labels
 -----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,33 @@ docker_service_enabled: "yes"
 docker_daemon_config: {}
 
 ##
+# Docker API cert
+##
+
+# Generate new cert on groups['docker_swarm_manager'][0]
+docker_api_certs_cert_gen: False
+
+# Base dir docker
+docker_api_certs_docker_base_path: /etc/docker
+# Base dir for cert.pem key.pem ca.pem (used for deamon.json)
+docker_api_certs_docker_cert_path: "{{ docker_api_certs_docker_base_path }}/cert"
+
+# used for deamon.json
+docker_api_certs_ca_name: ca.pem
+docker_api_certs_cert_name: cert.pem
+docker_api_certs_key_name: key.pem
+
+# Openssl config for generate CA
+docker_api_certs_openssl_domain: swarm.localdomain.local
+docker_api_certs_openssl_state: Ile-de-France
+docker_api_certs_openssl_country: FR
+docker_api_certs_openssl_email: docker@localhost
+docker_api_certs_openssl_org: My ORG
+docker_api_certs_openssl_ou: My OU
+
+docker_api_certs_docker_certificate_validity: 365
+
+##
 # Docker CLI
 ##
 
@@ -137,6 +164,7 @@ skip_containerd: false  # if true, skips the setup of containerd
 skip_engine: false      # if true, skips the docker engine installation
 skip_cli: false         # if true, skips the docker cli installation
 skip_swarm: false       # if true, skips the swarm setup
+skip_swarm_cert: false  # if true, skips the swarm cert gen and deploy
 skip_group: false       # if true, does not add the docker_admin_users to the docker_group_name
 skip_docker_py: false   # if true, skips the installation of docker-py
 skip_docker_compose: false  # if true, skips the installation of docker-compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,8 @@
 - block:
     - include_tasks: setup-swarm-cluster.yml
     - include_tasks: setup-swarm-labels.yml
+    - include_tasks: setup-docker-swarm-api-certs.yml
+      when: not skip_swarm_cert
   when: not skip_swarm
 
 # Adds the Docker admin users to the Docker group

--- a/tasks/setup-docker-swarm-api-certs.yml
+++ b/tasks/setup-docker-swarm-api-certs.yml
@@ -94,7 +94,7 @@
   become: True
 
 - name: Generate client crt
-  command: |
+  shell: |
     echo extendedKeyUsage = clientAuth > {{ docker_api_certs_docker_cert_path }}/client/extfile.cnf \
     && openssl x509 -req -days {{ docker_api_certs_docker_certificate_validity }} -sha256 \
        -in {{ docker_api_certs_docker_cert_path }}/client/client.csr \

--- a/tasks/setup-docker-swarm-api-certs.yml
+++ b/tasks/setup-docker-swarm-api-certs.yml
@@ -1,0 +1,182 @@
+---
+##
+# check prerequisites
+- name: Create certificate directory
+  file: path="{{ docker_api_certs_docker_cert_path }}" state=directory recurse=yes owner=root group=root mode=0755
+  become: True
+
+- name: Create CA certificate directory
+  file: path="{{ docker_api_certs_docker_cert_path }}/ca" state=directory recurse=yes owner=root group=root mode=0755
+  become: True
+
+- name: Create client certificate directory
+  file: path="{{ docker_api_certs_docker_cert_path }}/client" state=directory recurse=yes owner=root group=root mode=0755
+  become: True
+
+- name: Install OpenSSL
+  package:
+    name: openssl
+    state: present
+  become: True
+
+##
+# Gen cert files
+- name: copy openssl configuration
+  template:
+    src: templates/openssl.cnf.j2
+    dest: "{{ docker_api_certs_docker_cert_path }}/openssl-ca.cnf"
+    owner: root
+    group: root
+    mode: 0644
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  become: True
+
+- name: generate CA private key
+  command: openssl genrsa -out {{ docker_api_certs_docker_cert_path }}/ca/ca-key.pem 2048
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  become: True
+
+- name: generate CA public key
+  command: |
+    openssl req -config {{ docker_api_certs_docker_cert_path }}/openssl-ca.cnf -new -x509 \
+    -days {{ docker_api_certs_docker_certificate_validity }} \
+    -key {{ docker_api_certs_docker_cert_path }}/ca/ca-key.pem -sha256 \
+    -out {{ docker_api_certs_docker_cert_path }}/ca.pem
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  become: True
+
+- name: generate private keys
+  command: openssl genrsa -out {{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_key_name }} 2048
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  notify: restart docker
+  become: True
+
+- name: generate server csr (server.csr)
+  command: |
+    openssl req -subj "/CN={{ docker_api_certs_openssl_domain }}" -sha256 -new \
+    -key {{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_key_name }} \
+    -out {{ docker_api_certs_docker_cert_path }}/server.csr
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  become: True
+
+- name: generate public key
+  command: |
+    openssl x509 -req -days {{ docker_api_certs_docker_certificate_validity }} -sha256 \
+    -in {{ docker_api_certs_docker_cert_path }}/server.csr \
+    -CA {{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_ca_name }} \
+    -CAkey {{ docker_api_certs_docker_cert_path }}/ca/ca-key.pem \
+    -CAcreateserial -out {{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_cert_name }} \
+    -extfile {{ docker_api_certs_docker_cert_path }}/openssl-ca.cnf
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  notify: restart docker
+  become: True
+
+- name: generate client key
+  command: openssl genrsa -out {{ docker_api_certs_docker_cert_path }}/client/client-{{ docker_api_certs_key_name }} 2048
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  notify: restart docker
+  become: True
+
+- name: generate client csr (cert.csr)
+  command: |
+    openssl req -subj '/CN=client' -new \
+    -key {{ docker_api_certs_docker_cert_path }}/client/client-{{ docker_api_certs_key_name }} \
+    -out {{ docker_api_certs_docker_cert_path }}/client/client.csr
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  become: True
+
+- name: Generate client crt
+  command: |
+    echo extendedKeyUsage = clientAuth > {{ docker_api_certs_docker_cert_path }}/client/extfile.cnf \
+    && openssl x509 -req -days {{ docker_api_certs_docker_certificate_validity }} -sha256 \
+       -in {{ docker_api_certs_docker_cert_path }}/client/client.csr \
+       -CA {{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_ca_name }} \
+       -CAkey {{ docker_api_certs_docker_cert_path }}/ca/ca-key.pem -CAcreateserial \
+       -out {{ docker_api_certs_docker_cert_path }}/client/client-{{ docker_api_certs_cert_name }} \
+       -extfile {{ docker_api_certs_docker_cert_path }}/client/extfile.cnf
+  when: inventory_hostname == groups['docker_swarm_manager'][0] and docker_api_certs_cert_gen
+  run_once: True
+  become: True
+
+##
+# Get cert files if exist
+- name: get {{ docker_api_certs_ca_name }} from {{ groups['docker_swarm_manager'][0] }}
+  slurp:
+    src: "{{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_ca_name }}"
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  register: docker_api_certs_ca
+  run_once: True
+  become: True
+
+- name: get {{ docker_api_certs_cert_name }} from {{ groups['docker_swarm_manager'][0] }}
+  slurp:
+    src: "{{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_cert_name }}"
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  register: docker_api_certs_cert
+  run_once: True
+  become: True
+
+- name: get ca.pem from {{ groups['docker_swarm_manager'][0] }}
+  slurp:
+    src: "{{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_key_name }}"
+  delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
+  register: docker_api_certs_key
+  run_once: True
+  become: True
+
+##
+# Push cert files if don't exist
+- name: write ca.pem
+  copy:
+    dest: "{{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_ca_name }}"
+    content: "{{ docker_api_certs_ca['content'] | b64decode }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: inventory_hostname != groups['docker_swarm_manager'][0]
+  notify: restart docker
+  become: True
+
+- name: write cert.pem
+  copy:
+    dest: "{{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_cert_name }}"
+    content: "{{ docker_api_certs_cert['content'] | b64decode }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: inventory_hostname != groups['docker_swarm_manager'][0]
+  notify: restart docker
+  become: True
+
+- name: write key.pem
+  copy:
+    dest: "{{ docker_api_certs_docker_cert_path }}/{{ docker_api_certs_key_name }}"
+    content: "{{ docker_api_certs_key['content'] | b64decode }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: inventory_hostname != groups['docker_swarm_manager'][0]
+  notify: restart docker
+  become: True
+
+##
+# get a local copy of certs
+
+- name: get certs to localdir from {{ groups['docker_swarm_manager'][0] }}
+  fetch:
+    src: "{{ docker_api_certs_docker_cert_path }}/{{ item }}"
+    dest: "{{ docker_api_certs_docker_local_cert_path }}/"
+  with_items:
+    - "{{ docker_api_certs_ca_name }}"
+    - "{{ docker_api_certs_cert_name }}"
+    - "{{ docker_api_certs_key_name }}"
+  when: docker_api_certs_docker_local_cert_path is defined and inventory_hostname == groups['docker_swarm_manager'][0]
+  become: True

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -1,0 +1,11 @@
+[ req ]
+prompt                  = no
+distinguished_name      = req_distinguished_name
+
+[ req_distinguished_name ]
+commonName              = {{ docker_api_certs_openssl_domain }}
+stateOrProvinceName     = {{ docker_api_certs_openssl_state }}
+countryName             = {{ docker_api_certs_openssl_country }}
+emailAddress            = {{ docker_api_certs_openssl_email }}
+organizationName        = {{ docker_api_certs_openssl_org }}
+organizationalUnitName  = {{ docker_api_certs_openssl_ou }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,10 +1,10 @@
 ---
 
 python_pip_packages:
-  - python-pip
+  - "{% if ansible_facts.python.version.major is version('3', '=') %}python3-pip{% else %}python-pip{% endif %}"
 
 python_sni_support_packages:
-  - python-dev
+  - "{% if ansible_facts.python.version.major is version('3', '=') %}python3-dev{% else %}python-dev{% endif %}"
   - libssl-dev
   - libffi-dev
 


### PR DESCRIPTION
Detailed features
- Generate swarm client cert on groups['docker_swarm_manager'][0]
- Push certs on all swarm nodes
- Get a local copy of cert ( used by CI for exemple )