### PR TITLE
Allow adding custom values to Docker swarm labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can define labels by `swarm_labels` variable, e.g:
     swarm-01 swarm_labels=deploy
 
     [docker_swarm_worker]
-    swarm-02 swarm_labels='["libvirt", "docker", "foo", "bar"]'
+    swarm-02 swarm_labels='["libvirt", "docker", "foo", "bar", "cpu.arch=x86_64", "disk=ssd"]'
     swarm-03
     ...
 

--- a/tasks/setup-swarm-labels.yml
+++ b/tasks/setup-swarm-labels.yml
@@ -22,7 +22,7 @@
     - swarm_labels
 
 - name: Assign labels to swarm nodes if any.
-  command: docker node update --label-add {{ item }}=true {{ ansible_fqdn|lower }}
+  command: docker node update --label-add {{ item }}{% if '=' not in item %}=true{%endif%} {{ ansible_fqdn|lower }}
   when: item not in docker_swarm_labels.stdout_lines
   with_items:
     - "{{ swarm_labels  | default([]) }}"


### PR DESCRIPTION
## Feature

- Simply allow adding custom values to Docker swarm labels

No breaking changes : When user don't set '=' in label string, we keep legacy feature and we add '=true' as default value.