### PR TITLE
Handle python3-pip for Ubunt 20.04

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,10 +1,10 @@
 ---
 
 python_pip_packages:
-  - python-pip
+  - "{% if ansible_facts.python.version.major is version('3', '=') %}python3-pip{% else %}python-pip{% endif %}"
 
 python_sni_support_packages:
-  - python-dev
+  - "{% if ansible_facts.python.version.major is version('3', '=') %}python3-dev{% else %}python-dev{% endif %}"
   - libssl-dev
   - libffi-dev
 


### PR DESCRIPTION
- tries to address the issue raised by @higidi here, [link](https://github.com/atosatto/ansible-dockerswarm/pull/86#issuecomment-704522962)
- tested with Ubuntu 18.04 and Ubuntu 20.04
- credit to @jifox