### PR TITLE
Also check that swarm_labels variable is defined

### DIFF
--- a/tasks/setup-swarm-labels.yml
+++ b/tasks/setup-swarm-labels.yml
@@ -15,7 +15,7 @@
 - name: Remove labels from swarm node.
   command: docker node update --label-rm {{ item }} {{ ansible_fqdn|lower }}
   with_items: "{{ docker_swarm_labels.stdout_lines }}"
-  when: item not in swarm_labels
+  when: swarm_labels is defined and item not in swarm_labels
   delegate_to: "{{ groups['docker_swarm_manager'][0] }}"
   delegate_facts: true
   tags:


### PR DESCRIPTION
when removing labels as they could have been added outside this role,
thus making swarm_labels undefined.

Fixes upstream issue #96.